### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,6 +2,9 @@ name: Android CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Rve27/RvKernel-Manager/security/code-scanning/1](https://github.com/Rve27/RvKernel-Manager/security/code-scanning/1)

To address the issue, we will add a `permissions` block at the root level of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the actions used:
- `actions/checkout@v4` and `actions/upload-artifact@v4` require `contents: read` and `contents: write`, respectively.
- Other steps do not interact with repository contents or require additional permissions.

The explicit `permissions` block will look like this:
```yaml
permissions:
  contents: read
```
This ensures the workflow adheres to the principle of least privilege, while still functioning correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
