### PR TITLE
fix: Add policy3 big cluster detection and fix GPU multi-line parsing

### DIFF
--- a/app/src/main/java/com/rve/rvkernelmanager/ui/soc/SoCViewModel.kt
+++ b/app/src/main/java/com/rve/rvkernelmanager/ui/soc/SoCViewModel.kt
@@ -101,13 +101,41 @@ class SoCViewModel(application: Application) : AndroidViewModel(application) {
         data class Big(val cpuIndex: Int) :
             ClusterConfig(
                 name = "big",
-                minFreqPath = if (cpuIndex == 4) SoCUtils.MIN_FREQ_CPU4 else SoCUtils.MIN_FREQ_CPU6,
-                maxFreqPath = if (cpuIndex == 4) SoCUtils.MAX_FREQ_CPU4 else SoCUtils.MAX_FREQ_CPU6,
-                currentFreqPath = if (cpuIndex == 4) SoCUtils.CURRENT_FREQ_CPU4 else SoCUtils.CURRENT_FREQ_CPU6,
-                govPath = if (cpuIndex == 4) SoCUtils.GOV_CPU4 else SoCUtils.GOV_CPU6,
-                availableFreqPath = if (cpuIndex == 4) SoCUtils.AVAILABLE_FREQ_CPU4 else SoCUtils.AVAILABLE_FREQ_CPU6,
-                availableGovPath = if (cpuIndex == 4) SoCUtils.AVAILABLE_GOV_CPU4 else SoCUtils.AVAILABLE_GOV_CPU6,
-                availableBoostFreqPath = if (cpuIndex == 4) SoCUtils.AVAILABLE_BOOST_CPU4 else SoCUtils.AVAILABLE_BOOST_CPU6,
+                minFreqPath = when (cpuIndex) {
+                    3 -> SoCUtils.MIN_FREQ_CPU3
+                    4 -> SoCUtils.MIN_FREQ_CPU4
+                    else -> SoCUtils.MIN_FREQ_CPU6
+                },
+                maxFreqPath = when (cpuIndex) {
+                    3 -> SoCUtils.MAX_FREQ_CPU3
+                    4 -> SoCUtils.MAX_FREQ_CPU4
+                    else -> SoCUtils.MAX_FREQ_CPU6
+                },
+                currentFreqPath = when (cpuIndex) {
+                    3 -> SoCUtils.CURRENT_FREQ_CPU3
+                    4 -> SoCUtils.CURRENT_FREQ_CPU4
+                    else -> SoCUtils.CURRENT_FREQ_CPU6
+                },
+                govPath = when (cpuIndex) {
+                    3 -> SoCUtils.GOV_CPU3
+                    4 -> SoCUtils.GOV_CPU4
+                    else -> SoCUtils.GOV_CPU6
+                },
+                availableFreqPath = when (cpuIndex) {
+                    3 -> SoCUtils.AVAILABLE_FREQ_CPU3
+                    4 -> SoCUtils.AVAILABLE_FREQ_CPU4
+                    else -> SoCUtils.AVAILABLE_FREQ_CPU6
+                },
+                availableGovPath = when (cpuIndex) {
+                    3 -> SoCUtils.AVAILABLE_GOV_CPU3
+                    4 -> SoCUtils.AVAILABLE_GOV_CPU4
+                    else -> SoCUtils.AVAILABLE_GOV_CPU6
+                },
+                availableBoostFreqPath = when (cpuIndex) {
+                    3 -> SoCUtils.AVAILABLE_BOOST_CPU3
+                    4 -> SoCUtils.AVAILABLE_BOOST_CPU4
+                    else -> SoCUtils.AVAILABLE_BOOST_CPU6
+                },
             )
 
         object Prime : ClusterConfig(
@@ -258,6 +286,7 @@ class SoCViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun detectBigClusterConfig(): ClusterConfig.Big? {
         return when {
+            Utils.testFile(SoCUtils.AVAILABLE_FREQ_CPU3) -> ClusterConfig.Big(3)
             Utils.testFile(SoCUtils.AVAILABLE_FREQ_CPU4) -> ClusterConfig.Big(4)
             Utils.testFile(SoCUtils.AVAILABLE_FREQ_CPU6) -> ClusterConfig.Big(6)
             else -> null

--- a/app/src/main/java/com/rve/rvkernelmanager/utils/SoCUtils.kt
+++ b/app/src/main/java/com/rve/rvkernelmanager/utils/SoCUtils.kt
@@ -49,6 +49,14 @@ object SoCUtils {
     const val GOV_CPU0 = "/sys/devices/system/cpu/cpufreq/policy0/scaling_governor"
     const val AVAILABLE_GOV_CPU0 = "/sys/devices/system/cpu/cpufreq/policy0/scaling_available_governors"
 
+    const val MIN_FREQ_CPU3 = "/sys/devices/system/cpu/cpufreq/policy3/scaling_min_freq"
+    const val MAX_FREQ_CPU3 = "/sys/devices/system/cpu/cpufreq/policy3/scaling_max_freq"
+    const val CURRENT_FREQ_CPU3 = "/sys/devices/system/cpu/cpufreq/policy3/scaling_cur_freq"
+    const val AVAILABLE_FREQ_CPU3 = "/sys/devices/system/cpu/cpufreq/policy3/scaling_available_frequencies"
+    const val AVAILABLE_BOOST_CPU3 = "/sys/devices/system/cpu/cpufreq/policy3/scaling_boost_frequencies"
+    const val GOV_CPU3 = "/sys/devices/system/cpu/cpufreq/policy3/scaling_governor"
+    const val AVAILABLE_GOV_CPU3 = "/sys/devices/system/cpu/cpufreq/policy3/scaling_available_governors"
+
     const val MIN_FREQ_CPU4 = "/sys/devices/system/cpu/cpufreq/policy4/scaling_min_freq"
     const val MAX_FREQ_CPU4 = "/sys/devices/system/cpu/cpufreq/policy4/scaling_max_freq"
     const val CURRENT_FREQ_CPU4 = "/sys/devices/system/cpu/cpufreq/policy4/scaling_cur_freq"
@@ -206,10 +214,9 @@ object SoCUtils {
     fun readAvailableFreqGPU(filePath: String): List<String> = runCatching {
         val result = Shell.cmd("cat $filePath").exec()
         if (result.isSuccess) {
-            result.out.firstOrNull()
-                ?.trim()
-                ?.split(" ")
-                ?: emptyList()
+            result.out
+                .flatMap { it.trim().split("\\s+".toRegex()) }
+                .filter { it.isNotEmpty() }
         } else {
             Log.e("readAvailableFreqGPU", "Command execution failed: ${result.err}")
             emptyList()
@@ -222,10 +229,9 @@ object SoCUtils {
     fun readAvailableGovGPU(filePath: String): List<String> = runCatching {
         val result = Shell.cmd("cat $filePath").exec()
         if (result.isSuccess) {
-            result.out.firstOrNull()
-                ?.trim()
-                ?.split(" ")
-                ?: emptyList()
+            result.out
+                .flatMap { it.trim().split("\\s+".toRegex()) }
+                .filter { it.isNotEmpty() }
         } else {
             emptyList()
         }


### PR DESCRIPTION
## Summary

- **Add cpufreq policy3 support for big cluster detection.** Devices where the big cores start at policy3 (e.g. Snapdragon 8 Gen 2 on Sony Xperia 5V, pdx237) were not detected, causing the big cluster section to be entirely missing from the SoC screen. Adds policy3 sysfs path constants to `SoCUtils` and checks policy3 before policy4/policy6 in `detectBigClusterConfig()`.

- **Fix `readAvailableFreqGPU()` and `readAvailableGovGPU()` to handle multi-line sysfs output.** The previous implementation used `firstOrNull()` which only read the first line of output. Some kernels split GPU frequency tables and governor lists across multiple lines. Now uses `flatMap` over all output lines to capture all entries.

## Tested on
- Sony Xperia 5V (XQ-DE72, pdx237) — Snapdragon 8 Gen 2
- CPU topology: policy0 (4x A510), policy3 (4x A715), policy7 (1x X3)
- GPU: Adreno 740, single governor (msm-adreno-tz)
- LineageOS 23.0

## Test plan
- [x] Big cluster (policy3) now detected and displayed on SoC screen
- [x] CPU frequency and governor controls functional for all three clusters
- [x] GPU frequency list fully populated from multi-line sysfs output
- [x] GPU governor list fully populated from multi-line sysfs output
- [x] No regression on policy4/policy6 devices (code path unchanged for those indices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)